### PR TITLE
Change layout of projects page

### DIFF
--- a/_includes/project.html
+++ b/_includes/project.html
@@ -1,6 +1,6 @@
 <figure class="project">
-  
-  <a href="{{ include.project.product-url }}" class="project-image-frame" style="background-color: {{ include.project.brand-color }};">
+
+  <a href="{{ include.project.product-url }}" target="_blank" class="project-image-frame" style="background-color: {{ include.project.brand-color }};">
     <img src="{{ include.project.image-src}}" class="project-image {{ include.project.platform }}" />
   </a>
 
@@ -8,7 +8,7 @@
 
     <header class="project-header">
       <h1 class="project-title">
-        <a href="{{ include.project.product-url }}">
+        <a href="{{ include.project.product-url }}" target="_blank">
           {{ include.project.title }}
         </a>
       </h1>

--- a/assets/style/main.css
+++ b/assets/style/main.css
@@ -122,10 +122,6 @@ section.projects {
     position: relative;
   }
 
-  figure.project:nth-child(even) {
-    flex-direction: row-reverse;
-  }
-
     figure.project > * {
       width: 50%;
       margin: 0 10px 0 10px;

--- a/assets/style/main.css
+++ b/assets/style/main.css
@@ -13,6 +13,14 @@ a:hover {
   text-decoration: underline;
 }
 
+p {
+  font-family: "AvenirNext-Regular";
+  font-size: 16px;
+  color: #444444;
+  letter-spacing: 0.59px;
+  line-height: 30px;
+}
+
 .container {
   margin: 0 auto 0 auto;
   /*background-color: red;*/
@@ -22,6 +30,10 @@ a:hover {
 
 .bold {
   font-weight: bold;
+}
+
+#coming-soon {
+  text-align: center;
 }
 
 /* header.html */

--- a/blog.html
+++ b/blog.html
@@ -4,3 +4,4 @@ title: "Blog"
 nav-order: 2
 permalink: "blog"
 ---
+<p id="coming-soon">Coming Soon.</p>

--- a/index.html
+++ b/index.html
@@ -3,3 +3,4 @@ layout: default
 title: "About"
 nav-order: 1
 ---
+<p id="coming-soon">Coming Soon.</p>


### PR DESCRIPTION
The projects page is currently in a staggered formation which is makes it confusing which project description is paired with which project image.

Instead, the project images are all on the left side and there description on the right.